### PR TITLE
[MF-5] 병원 구직 데이터 조회 및 저장

### DIFF
--- a/src/main/java/com/medifitbe/jobdata/adapter/JobValidationController.java
+++ b/src/main/java/com/medifitbe/jobdata/adapter/JobValidationController.java
@@ -1,0 +1,40 @@
+package com.medifitbe.jobdata.adapter;
+
+
+import com.medifitbe.jobdata.adapter.in.request.JobDataRequest;
+import com.medifitbe.jobdata.adapter.in.response.JobDataResponse;
+import com.medifitbe.jobdata.application.service.JobValidationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/jobs")
+@Tag(name = "Job Validation", description = "채용 공고 검증 관련 API")
+public class JobValidationController {
+
+    private final JobValidationService validationService;
+
+    @Operation(summary = "검증되지 않은 채용 공고 목록 조회")
+    @GetMapping("/unvalidated")
+    public List<JobDataResponse> getUnvalidated() {
+        return validationService.getAllUnvalidated()
+                .stream()
+                .map(JobDataResponse::from)
+                .toList();
+    }
+
+    @Operation(summary = "채용 공고 검증 및 저장")
+    @PostMapping("/validate")
+    public ResponseEntity<Void> validateJob(
+            @RequestBody JobDataRequest modifiedData) {
+        validationService.validateAndSave(modifiedData);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/medifitbe/jobdata/adapter/in/request/JobDataRequest.java
+++ b/src/main/java/com/medifitbe/jobdata/adapter/in/request/JobDataRequest.java
@@ -1,0 +1,21 @@
+package com.medifitbe.jobdata.adapter.in.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채용 데이터 요청 DTO")
+@Builder
+public record JobDataRequest(
+    @Schema(description = "사이트 이름", example = "인크루트") @NotBlank String siteName,
+    @Schema(description = "병원 이름", example = "서울삼성안과의원") @NotBlank String hospitalName,
+    @Schema(description = "공고 제목", example = "정규직 간호조무사 모집") @NotBlank String jobTitle,
+    @Schema(description = "지역", example = "서울특별시 강남구") String location,
+    @Schema(description = "급여", example = "월급 220만원") String salary,
+    @Schema(description = "경력", example = "신입") String experience,
+    @Schema(description = "마감일", example = "상시모집") String deadline,
+    @Schema(description = "근무 요일", example = "월~금") String workingDays,
+    @Schema(description = "복지", example = "4대 보험, 중식 제공") String welfare,
+    @Schema(description = "담당 업무", example = "진료 보조, 환자 응대") String responsibilities,
+    @Schema(description = "상세 링크", example = "https://example.com/job/1234") String link
+) {}

--- a/src/main/java/com/medifitbe/jobdata/adapter/in/response/JobDataResponse.java
+++ b/src/main/java/com/medifitbe/jobdata/adapter/in/response/JobDataResponse.java
@@ -1,0 +1,35 @@
+package com.medifitbe.jobdata.adapter.in.response;
+
+import com.medifitbe.jobdata.adapter.out.persistence.entity.JobDataEntity;
+
+public record JobDataResponse(
+        Long id,
+        String siteName,
+        String hospitalName,
+        String jobTitle,
+        String location,
+        String salary,
+        String experience,
+        String deadline,
+        String workingDays,
+        String welfare,
+        String responsibilities,
+        String link
+) {
+    public static JobDataResponse from(JobDataEntity jobDataEntity) {
+        return new JobDataResponse(
+            jobDataEntity.getId(),
+            jobDataEntity.getSiteName(),
+            jobDataEntity.getHospitalName(),
+            jobDataEntity.getJobTitle(),
+            jobDataEntity.getLocation(),
+            jobDataEntity.getSalary(),
+            jobDataEntity.getExperience(),
+            jobDataEntity.getDeadline(),
+            jobDataEntity.getWorkingDays(),
+            jobDataEntity.getWelfare(),
+            jobDataEntity.getResponsibilities(),
+            jobDataEntity.getLink()
+        );
+    }
+}

--- a/src/main/java/com/medifitbe/jobdata/adapter/out/persistence/entity/JobDataEntity.java
+++ b/src/main/java/com/medifitbe/jobdata/adapter/out/persistence/entity/JobDataEntity.java
@@ -1,0 +1,36 @@
+package com.medifitbe.jobdata.adapter.out.persistence.entity;
+
+import com.medifitbe.core.entity.TimeBaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Table(name = "job_data")
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class JobDataEntity extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String siteName;         // 사이트 이름
+    private String hospitalName;     // 병원명
+    private String jobTitle;         // 공고 제목
+    private String location;         // 지역
+    private String salary;           // 급여
+    private String experience;       // 경력
+    private String deadline;         // 마감일
+    private String workingDays;      // 근무요일
+    private String welfare;          // 복지
+    private String responsibilities; // 담당업무
+
+    @Column(length = 1000)
+    private String link;             // 공고 상세 링크
+}

--- a/src/main/java/com/medifitbe/jobdata/adapter/out/persistence/entity/ValidatedJobDataEntity.java
+++ b/src/main/java/com/medifitbe/jobdata/adapter/out/persistence/entity/ValidatedJobDataEntity.java
@@ -1,0 +1,39 @@
+package com.medifitbe.jobdata.adapter.out.persistence.entity;
+
+import com.medifitbe.core.entity.TimeBaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+
+@Table(name = "validated_job_data")
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class ValidatedJobDataEntity extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String siteName;
+    private String hospitalName;
+    private String jobTitle;
+    private String location;
+    private String salary;
+    private String experience;
+    private String deadline;
+    private String workingDays;
+    private String welfare;
+
+    @Column(length = 1000)
+    private String responsibilities;
+
+    @Column(length = 1000)
+    private String link;
+}

--- a/src/main/java/com/medifitbe/jobdata/adapter/out/persistence/repository/JobDataRepository.java
+++ b/src/main/java/com/medifitbe/jobdata/adapter/out/persistence/repository/JobDataRepository.java
@@ -1,0 +1,10 @@
+package com.medifitbe.jobdata.adapter.out.persistence.repository;
+
+
+import com.medifitbe.jobdata.adapter.out.persistence.entity.JobDataEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JobDataRepository extends JpaRepository<JobDataEntity, Long> {
+}

--- a/src/main/java/com/medifitbe/jobdata/adapter/out/persistence/repository/ValidatedJobDataRepository.java
+++ b/src/main/java/com/medifitbe/jobdata/adapter/out/persistence/repository/ValidatedJobDataRepository.java
@@ -1,0 +1,9 @@
+package com.medifitbe.jobdata.adapter.out.persistence.repository;
+
+import com.medifitbe.jobdata.adapter.out.persistence.entity.ValidatedJobDataEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ValidatedJobDataRepository extends JpaRepository<ValidatedJobDataEntity, Long> {
+}

--- a/src/main/java/com/medifitbe/jobdata/application/service/JobValidationService.java
+++ b/src/main/java/com/medifitbe/jobdata/application/service/JobValidationService.java
@@ -1,0 +1,42 @@
+package com.medifitbe.jobdata.application.service;
+
+import com.medifitbe.jobdata.adapter.in.request.JobDataRequest;
+import com.medifitbe.jobdata.adapter.out.persistence.entity.JobDataEntity;
+import com.medifitbe.jobdata.adapter.out.persistence.entity.ValidatedJobDataEntity;
+import com.medifitbe.jobdata.adapter.out.persistence.repository.JobDataRepository;
+import com.medifitbe.jobdata.adapter.out.persistence.repository.ValidatedJobDataRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class JobValidationService {
+
+    private final JobDataRepository jobDataRepository;
+    private final ValidatedJobDataRepository validatedRepository;
+
+    public List<JobDataEntity> getAllUnvalidated() {
+        return jobDataRepository.findAll();
+    }
+
+    public void validateAndSave(JobDataRequest modifiedData) {
+        ValidatedJobDataEntity validated = ValidatedJobDataEntity.builder()
+                .siteName(modifiedData.siteName())
+                .hospitalName(modifiedData.hospitalName())
+                .jobTitle(modifiedData.jobTitle())
+                .location(modifiedData.location())
+                .salary(modifiedData.salary())
+                .experience(modifiedData.experience())
+                .deadline(modifiedData.deadline())
+                .workingDays(modifiedData.workingDays())
+                .welfare(modifiedData.welfare())
+                .responsibilities(modifiedData.responsibilities())
+                .link(modifiedData.link())
+                .build();
+
+        validatedRepository.save(validated);
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
* 크롤링된 병원 구직 데이터를 조회할 수 있도록 하고, 선택한 데이터를 검토 및 수정한 뒤 검증된 테이블로 이관하는 기능을 구현

---

## ✅ 작업 내용
1. 크롤링된 원시 데이터(job_data 테이블) 전체 리스트 조회 API 구현
2. 기존 데이터를 수정하여 전달받은 후 검증 테이블에 저장

---


## 📂 리뷰 요구사항
- 구조 추후 리팩토링 예정
-
-
---

