### PR TITLE
[MF-11] 맞춤공고 서비스 추전 방식 수정

### DIFF
--- a/src/main/java/com/medifitbe/jobdata/adapter/out/persistence/repository/JobRecommendationHistoryRepository.java
+++ b/src/main/java/com/medifitbe/jobdata/adapter/out/persistence/repository/JobRecommendationHistoryRepository.java
@@ -3,6 +3,9 @@ package com.medifitbe.jobdata.adapter.out.persistence.repository;
 import com.medifitbe.jobdata.adapter.out.persistence.entity.JobRecommendationHistoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface JobRecommendationHistoryRepository extends JpaRepository<JobRecommendationHistoryEntity, Long> {
     boolean existsBySubscriberIdAndJobId(Long subscriberId, Long jobId);
+    Optional<JobRecommendationHistoryEntity> findTopBySubscriberIdOrderByCreatedAtDesc(Long subscriberId);
 }

--- a/src/main/java/com/medifitbe/jobdata/application/service/JobRecommendationEngine.java
+++ b/src/main/java/com/medifitbe/jobdata/application/service/JobRecommendationEngine.java
@@ -3,21 +3,44 @@ package com.medifitbe.jobdata.application.service;
 import com.medifitbe.jobdata.adapter.out.persistence.entity.JobDataEntity;
 import com.medifitbe.jobdata.domain.JobRecommendation;
 import com.medifitbe.user.domain.Subscriber;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.medifitbe.jobdata.adapter.out.persistence.repository.JobRecommendationHistoryRepository;
+
 @Service
 public class JobRecommendationEngine {
+
+    private final JobRecommendationHistoryRepository jobRecommendationHistoryRepository;
+
+    @Autowired
+    public JobRecommendationEngine(JobRecommendationHistoryRepository jobRecommendationHistoryRepository) {
+        this.jobRecommendationHistoryRepository = jobRecommendationHistoryRepository;
+    }
 
     public List<JobRecommendation> recommend(List<JobDataEntity> jobs, Subscriber subscriber) {
         List<JobRecommendation> results = new ArrayList<>();
 
-        for (JobDataEntity job : jobs) {
+        // Find the most recent recommendation time for the subscriber (as Instant)
+        Instant latestRecommendationTime = jobRecommendationHistoryRepository
+                .findTopBySubscriberIdOrderByCreatedAtDesc(subscriber.getId())
+                .map(rec -> rec.getCreatedAt().atZone(ZoneId.systemDefault()).toInstant())
+                .orElse(Instant.EPOCH); // fallback to a reasonable default
+
+        // Only include jobs created after the latest recommendation time
+        List<JobDataEntity> newJobs = jobs.stream()
+                .filter(job -> job.getCreatedAt() != null &&
+                        job.getCreatedAt().atZone(ZoneId.systemDefault()).toInstant().isAfter(latestRecommendationTime))
+                .toList();
+
+        for (JobDataEntity job : newJobs) {
             double score = computeSimilarity(subscriber, job);
             if (score >= 0.4) {
                 results.add(JobRecommendation.builder()

--- a/src/main/java/com/medifitbe/jobdata/application/service/JobRecommendationService.java
+++ b/src/main/java/com/medifitbe/jobdata/application/service/JobRecommendationService.java
@@ -34,15 +34,23 @@ public class JobRecommendationService {
                 .stream()
                 .map(subscriberMapper::toDomain)
                 .toList();
+        // System.out.println("총 구독자 수: " + allSubscribers.size());
+        // System.out.println("총 채용 공고 수: " + allJobs.size());
 
         Map<String, List<JobRecommendation>> result = new HashMap<>();
         allSubscribers.forEach(subscriber -> {
             List<JobRecommendation> recommendations = recommendationEngine.recommend(allJobs, subscriber);
+            // System.out.println("[" + subscriber.getEmail() + "] 추천된 개수: " + recommendations.size());
 
             // 중복 제거
             List<JobRecommendation> filtered = recommendations.stream()
-                    .filter(rec -> !historyRepository.existsBySubscriberIdAndJobId(subscriber.getId(), rec.getJobId()))
+                    .filter(rec -> {
+                        boolean alreadyExists = historyRepository.existsBySubscriberIdAndJobId(subscriber.getId(), rec.getJobId());
+                        // if (alreadyExists) System.out.println("🚫 이미 추천된 jobId: " + rec.getJobId());
+                        return !alreadyExists;
+                    })
                     .toList();
+            // System.out.println("[" + subscriber.getEmail() + "] 신규 추천 개수: " + filtered.size());
 
             // 추천 이력 저장
             filtered.stream()

--- a/src/main/java/com/medifitbe/mail/application/service/EmailBroadcastService.java
+++ b/src/main/java/com/medifitbe/mail/application/service/EmailBroadcastService.java
@@ -25,9 +25,9 @@ public class EmailBroadcastService {
             mailService.sendTo(subscriber.getEmail(), subject, content);
         }
     }
-    @Scheduled(cron = "0 0 */3 * * *")
-    //@Scheduled(cron = "0 */10 * * * *")
+    @Scheduled(cron = "0 0 9,12,15,18,21 * * *")
     public void sendRecommendations() {
+        System.out.println("스케줄링 실행");
         Map<String, List<JobRecommendation>> recommendationsMap = jobRecommendationService.recommendForAllUsers();
 
         for (Map.Entry<String, List<JobRecommendation>> entry : recommendationsMap.entrySet()) {


### PR DESCRIPTION
📌 작업 개요
	•	구독자별로 마지막 추천된 시간 이후에 등록된 공고만 대상으로 추천하는 기능 추가

⸻

✅ 작업 내용
	1.	JobRecommendationEngine에서 JobRecommendationHistory 기준으로 최근 추천 시점을 조회
	2.	각 공고의 createdAt 값이 해당 시점 이후인 경우에만 필터링하여 추천
	3.	스케줄링을 낮시간에만 돌아가도록 수정

⸻

🔗 관련 이슈
	•	Closes #11 #12

⸻

📂 리뷰 요구사항
	•	createdAt 기반 추천 필터링이 정상적으로 적용되었는지 확인 부탁드립니다.
	•	Instant 변환 시 오류가 발생하지 않도록 ZoneId.systemDefault() 처리 방식 검토 부탁드립니다.
	•	추천 결과가 기대한 대로 제한된 공고만 포함되는지 확인 바랍니다.