### PR TITLE
[MF-14] 구독자 정보 삭제

### DIFF
--- a/src/main/java/com/medifitbe/user/adapter/SubscriberApi.java
+++ b/src/main/java/com/medifitbe/user/adapter/SubscriberApi.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Subscriber", description = "구독자 관련 API")

--- a/src/main/java/com/medifitbe/user/adapter/SubscriberApi.java
+++ b/src/main/java/com/medifitbe/user/adapter/SubscriberApi.java
@@ -1,6 +1,7 @@
 package com.medifitbe.user.adapter;
 
 import com.medifitbe.user.adapter.in.request.CreateSubscriberRequest;
+import com.medifitbe.user.adapter.in.request.DeleteSubscriberRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -12,6 +13,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface SubscriberApi {
 
     @Operation(summary = "구독자 등록")
-    @PostMapping("/api/v1/subscribers")
     ResponseEntity<Void> createSubscriber(@RequestBody @Valid CreateSubscriberRequest request);
+
+    @Operation(summary = "이메일로 구독자 삭제")
+    ResponseEntity<Void> deleteByEmail(@RequestBody @Valid DeleteSubscriberRequest email);
 }
+

--- a/src/main/java/com/medifitbe/user/adapter/SubscriberController.java
+++ b/src/main/java/com/medifitbe/user/adapter/SubscriberController.java
@@ -1,21 +1,31 @@
 package com.medifitbe.user.adapter;
 
 import com.medifitbe.user.adapter.in.request.CreateSubscriberRequest;
+import com.medifitbe.user.adapter.in.request.DeleteSubscriberRequest;
 import com.medifitbe.user.application.port.in.CreateSubscriberUseCase;
+import com.medifitbe.user.application.port.in.DeleteSubscriberUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/api/v1/subscribers")
 @RequiredArgsConstructor
 public class SubscriberController implements SubscriberApi {
 
     private final CreateSubscriberUseCase createSubscriberUseCase;
+    private final DeleteSubscriberUseCase deleteSubscriberUseCase;
 
-    @Override
+    @PostMapping
     public ResponseEntity<Void> createSubscriber(@Valid CreateSubscriberRequest request) {
         createSubscriberUseCase.create(request);
         return ResponseEntity.ok().build();
     }
+    @DeleteMapping
+    public ResponseEntity<Void> deleteByEmail(@Valid DeleteSubscriberRequest request) {
+        deleteSubscriberUseCase.deleteByEmail(request.email());
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/medifitbe/user/adapter/in/request/CreateSubscriberRequest.java
+++ b/src/main/java/com/medifitbe/user/adapter/in/request/CreateSubscriberRequest.java
@@ -24,7 +24,7 @@ public record CreateSubscriberRequest(
         @Schema(description = "희망 진료과", example = "[\"내과\", \"정신건강의학과\"]")
         List<Department> departments,
 
-        @Schema(description = "희망 근무 형태", example = "[\"풀타임\", \"상관없음\"]")
+        @Schema(description = "희망 근무 형태", example = "[\"풀타임\"]")
         List<WorkType> workTypes,
 
         @Schema(description = "근무 가능 요일", example = "[\"월\", \"화\", \"수\"]")
@@ -33,7 +33,7 @@ public record CreateSubscriberRequest(
         @Schema(description = "주말 근무 가능 여부", example = "가급적 쉬고 싶음")
         WeekendWork weekendWork,
 
-        @Schema(description = "복지 선호", example = "[\"식대\", \"연차보장\"]")
+        @Schema(description = "복지 선호", example = "[\"식대\", \"연차 보장\"]")
         List<Welfare> welfarePreferences,
 
         @Schema(description = "급여 단위", example = "월급")

--- a/src/main/java/com/medifitbe/user/adapter/in/request/DeleteSubscriberRequest.java
+++ b/src/main/java/com/medifitbe/user/adapter/in/request/DeleteSubscriberRequest.java
@@ -1,0 +1,14 @@
+package com.medifitbe.user.adapter.in.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record DeleteSubscriberRequest(
+
+        @Schema(description = "삭제할 구독자의 이메일", example = "user@example.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "유효한 이메일 형식이어야 합니다.")
+        String email
+
+) {}

--- a/src/main/java/com/medifitbe/user/adapter/out/persistence/SubscriberPersistenceAdapter.java
+++ b/src/main/java/com/medifitbe/user/adapter/out/persistence/SubscriberPersistenceAdapter.java
@@ -2,7 +2,6 @@ package com.medifitbe.user.adapter.out.persistence;
 
 import com.medifitbe.user.adapter.out.persistence.entity.SubscriberEntity;
 import com.medifitbe.user.adapter.out.persistence.repository.SubscriberRepository;
-import com.medifitbe.user.application.port.in.DeleteSubscriberUseCase;
 import com.medifitbe.user.application.port.out.CreateSubscriberPort;
 import com.medifitbe.user.application.port.out.DeleteSubscriberPort;
 import com.medifitbe.user.domain.Subscriber;

--- a/src/main/java/com/medifitbe/user/adapter/out/persistence/SubscriberPersistenceAdapter.java
+++ b/src/main/java/com/medifitbe/user/adapter/out/persistence/SubscriberPersistenceAdapter.java
@@ -2,7 +2,9 @@ package com.medifitbe.user.adapter.out.persistence;
 
 import com.medifitbe.user.adapter.out.persistence.entity.SubscriberEntity;
 import com.medifitbe.user.adapter.out.persistence.repository.SubscriberRepository;
+import com.medifitbe.user.application.port.in.DeleteSubscriberUseCase;
 import com.medifitbe.user.application.port.out.CreateSubscriberPort;
+import com.medifitbe.user.application.port.out.DeleteSubscriberPort;
 import com.medifitbe.user.domain.Subscriber;
 import com.medifitbe.user.mapper.SubscriberMapper;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class SubscriberPersistenceAdapter implements CreateSubscriberPort {
+public class SubscriberPersistenceAdapter implements CreateSubscriberPort, DeleteSubscriberPort {
 
     private final SubscriberRepository repository;
 
@@ -18,5 +20,10 @@ public class SubscriberPersistenceAdapter implements CreateSubscriberPort {
     public void save(Subscriber subscriber) {
         SubscriberEntity entity = SubscriberMapper.toEntity(subscriber);
         repository.save(entity);
+    }
+
+    @Override
+    public void deleteByEmail(String email) {
+        repository.deleteByEmail(email);
     }
 }

--- a/src/main/java/com/medifitbe/user/adapter/out/persistence/repository/SubscriberRepository.java
+++ b/src/main/java/com/medifitbe/user/adapter/out/persistence/repository/SubscriberRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 @Repository
 public interface SubscriberRepository extends JpaRepository<SubscriberEntity, Long> {
     List<SubscriberEntity> findAll();
-
+    void deleteByEmail(String email);
 }

--- a/src/main/java/com/medifitbe/user/application/port/in/DeleteSubscriberUseCase.java
+++ b/src/main/java/com/medifitbe/user/application/port/in/DeleteSubscriberUseCase.java
@@ -1,0 +1,5 @@
+package com.medifitbe.user.application.port.in;
+
+public interface DeleteSubscriberUseCase {
+    void deleteByEmail(String email);
+}

--- a/src/main/java/com/medifitbe/user/application/port/out/DeleteSubscriberPort.java
+++ b/src/main/java/com/medifitbe/user/application/port/out/DeleteSubscriberPort.java
@@ -1,0 +1,5 @@
+package com.medifitbe.user.application.port.out;
+
+public interface DeleteSubscriberPort {
+    void deleteByEmail(String email);
+}

--- a/src/main/java/com/medifitbe/user/application/service/CreateSubscriberService.java
+++ b/src/main/java/com/medifitbe/user/application/service/CreateSubscriberService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CreateSubscriberService implements CreateSubscriberUseCase {
 
     private final CreateSubscriberPort createSubscriberPort;

--- a/src/main/java/com/medifitbe/user/application/service/DeleteSubscriberService.java
+++ b/src/main/java/com/medifitbe/user/application/service/DeleteSubscriberService.java
@@ -1,0 +1,20 @@
+package com.medifitbe.user.application.service;
+
+import com.medifitbe.user.application.port.in.DeleteSubscriberUseCase;
+import com.medifitbe.user.application.port.out.DeleteSubscriberPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteSubscriberService implements DeleteSubscriberUseCase {
+
+    private final DeleteSubscriberPort deleteSubscriberPort;
+
+    @Override
+    public void deleteByEmail(String email) {
+        deleteSubscriberPort.deleteByEmail(email);
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
*  구독자 정보 삭제 기능

---

## ✅ 작업 내용
1. 이메일로 구독자 정보를 삭제

---


## 📂 리뷰 요구사항
- 구독자 정보 비활성화시 추후 재가입시 중복에 걸리므로 하드 삭제
-
-
---

